### PR TITLE
Hide AWS credentials generation option from right mouse menu

### DIFF
--- a/Assets/com.edia.uxf/Runtime/Scripts/Etc/AWSCredentials.cs
+++ b/Assets/com.edia.uxf/Runtime/Scripts/Etc/AWSCredentials.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace UXF
 {
 
-    [CreateAssetMenu(fileName = "MyAWSCredentials", menuName = "UXF/AWS Credentials", order = 1)]
+    // [CreateAssetMenu(fileName = "MyAWSCredentials", menuName = "UXF/AWS Credentials", order = 1)]
     public class AWSCredentials : ScriptableObject
     {
         public string region;


### PR DESCRIPTION
HOly moly this shit is confusing, i was somehow doing thing in the original UXF
And I was assuming there still was a branch with this name.

Anyhow.
See title