### PR TITLE
Check if there is a stringlist in the trialsettings that is logged an…

### DIFF
--- a/Assets/com.edia.uxf/Runtime/Scripts/Etc/Trial.cs
+++ b/Assets/com.edia.uxf/Runtime/Scripts/Etc/Trial.cs
@@ -301,7 +301,15 @@ namespace UXF
             // log any settings we need to for this trial
             foreach (string s in session.settingsToLog)
             {
-                result[s] = settings.GetObject(s, string.Empty);
+                var settingObject = settings.GetObject(s, string.Empty);
+                if (settingObject is List<string> stringList)
+                {
+                    result[s] = string.Join(";", stringList);
+                }
+                else
+                {
+                    result[s] = settingObject.ToString();
+                }
             }
         }
 


### PR DESCRIPTION
By default a List<string> is not logged properly in the `trialresults.csv` file. 
As we use 'value;value;value` in the config file settings, we also want this formatted the same way in the results. 