### PR TITLE
fix to correct IList (re: !13)

### DIFF
--- a/Assets/com.edia.uxf/Runtime/Scripts/Etc/Trial.cs
+++ b/Assets/com.edia.uxf/Runtime/Scripts/Etc/Trial.cs
@@ -303,7 +303,7 @@ namespace UXF
             {
                 var settingObject = settings.GetObject(s, string.Empty);
 
-                if (settingObject is IList list)
+                if (settingObject is System.Collections.IList list)
                     result[s] = string.Join(";", list.OfType<object>().Select(o => o?.ToString() ?? ""));
                 else
                     result[s] = settingObject?.ToString() ?? string.Empty;


### PR DESCRIPTION
#12 introduced faulty code. 
This fixes it by choosing the correct IList interface. 

Note that this will still not work properly for Dicts and otehr enumerables. But this is a super-rare case anyway which only applies if a user manually stores settings directly to the session & manually adds the setting to be saved. 